### PR TITLE
Tested on 9.0.2 and 9.2.2

### DIFF
--- a/libsodium/libsodium.cabal
+++ b/libsodium/libsodium.cabal
@@ -13,7 +13,7 @@ synopsis: Low-level bindings to the libsodium C library
 description: Low-level bindings to the libsodium C library
 homepage: https://github.com/k0001/hs-libsodium
 bug-reports: https://github.com/k0001/hs-libsodium/issues
-tested-with: GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
+tested-with: GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.2, GHC == 9.2.2
 
 common basic
   default-language: Haskell2010


### PR DESCRIPTION
Address issues pointed out on https://github.com/haskell-cryptography/cryptography-libsodium-bindings#comparison-with-other-libraries
