### PR TITLE
Update to 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Require sodium 1.0.19
+
 # Version 1.0.18.3
 
 * Allocation tools such as `crypto_aead_aes256gcm_state'malloc` now

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 , tasty-hunit }:
 mkDerivation {
   pname = "libsodium";
-  version = "1.0.18.3";
+  version = "1.0.19.0";
   src = lib.sources.cleanSource ./.;
   libraryToolDepends = [ c2hs ];
   libraryHaskellDepends = [ base ];

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677995890,
-        "narHash": "sha256-eOnCn0o3I6LP48fAi8xWFcn49V2rL7oX5jCtJTeN1LI=",
+        "lastModified": 1727907660,
+        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1240f6b4a0bcc84fc48008b396a140d9f3638f6",
+        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   description = "Haskell libsodium library";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
   outputs = { self, nixpkgs }:
     let
       pkgsOverlay = pself: psuper: {

--- a/flake.nix
+++ b/flake.nix
@@ -29,21 +29,21 @@
                 s = self.devShells.${system};
               in [
                 p.libsodium__ghcDefault
-                p.libsodium__ghc925
-                p.libsodium__ghc943
+                p.libsodium__ghc92
+                p.libsodium__ghc94
 
                 p.libsodium__ghcDefault.doc
-                p.libsodium__ghc925.doc
-                p.libsodium__ghc943.doc
+                p.libsodium__ghc92.doc
+                p.libsodium__ghc94.doc
 
                 s.libsodium__ghcDefault
-                s.libsodium__ghc925
-                s.libsodium__ghc943
+                s.libsodium__ghc92
+                s.libsodium__ghc94
               ];
             };
             libsodium__ghcDefault = pkgs.haskellPackages.libsodium;
-            libsodium__ghc925 = pkgs.haskell.packages.ghc925.libsodium;
-            libsodium__ghc943 = pkgs.haskell.packages.ghc943.libsodium;
+            libsodium__ghc92 = pkgs.haskell.packages.ghc92.libsodium;
+            libsodium__ghc94 = pkgs.haskell.packages.ghc94.libsodium;
           });
       devShells =
         nixpkgs.lib.genAttrs [ "x86_64-linux" "i686-linux" "aarch64-linux" ]
@@ -57,10 +57,10 @@
                 nativeBuildInputs = [ pkgs.cabal-install pkgs.cabal2nix ];
               };
           in {
-            default = self.devShells.${system}.libsodium__ghc943;
+            default = self.devShells.${system}.libsodium__ghc94;
             libsodium__ghcDefault = mkShellFor pkgs.haskellPackages;
-            libsodium__ghc925 = mkShellFor pkgs.haskell.packages.ghc925;
-            libsodium__ghc943 = mkShellFor pkgs.haskell.packages.ghc943;
+            libsodium__ghc92 = mkShellFor pkgs.haskell.packages.ghc92;
+            libsodium__ghc94 = mkShellFor pkgs.haskell.packages.ghc94;
           });
     };
 }

--- a/hs/Libsodium/Constants.hs
+++ b/hs/Libsodium/Constants.hs
@@ -297,8 +297,9 @@ TN(CRYPTO_VERIFY_32_BYTES, 32, CSize, crypto_verify_32_bytes)
 TN(CRYPTO_VERIFY_64_BYTES, 64, CSize, crypto_verify_64_bytes)
 TN(RANDOMBYTES_SEEDBYTES, 32, CSize, randombytes_seedbytes)
 TN(SODIUM_LIBRARY_MINIMAL, 0, CInt, sodium_library_minimal)
-TN(SODIUM_LIBRARY_VERSION_MAJOR, 10, CInt, sodium_library_version_major)
-TN(SODIUM_LIBRARY_VERSION_MINOR, 3, CInt, sodium_library_version_minor)
+-- https://github.com/jedisct1/libsodium/blob/1.0.19/configure.ac
+TN(SODIUM_LIBRARY_VERSION_MAJOR, 26, CInt, sodium_library_version_major)
+TN(SODIUM_LIBRARY_VERSION_MINOR, 1, CInt, sodium_library_version_minor)
 
 -- These have no corresponding C functions
 TN(SODIUM_BASE64_VARIANT_ORIGINAL, 1, CInt, sodium_base64_variant_original)
@@ -341,4 +342,4 @@ TS(CRYPTO_SECRETBOX_PRIMITIVE, "xsalsa20poly1305", crypto_secretbox_primitive)
 TS(CRYPTO_SHORTHASH_PRIMITIVE, "siphash24", crypto_shorthash_primitive)
 TS(CRYPTO_SIGN_PRIMITIVE, "ed25519", crypto_sign_primitive)
 TS(CRYPTO_STREAM_PRIMITIVE, "xsalsa20", crypto_stream_primitive)
-TS(SODIUM_VERSION_STRING, "1.0.18", sodium_version_string)
+TS(SODIUM_VERSION_STRING, "1.0.19", sodium_version_string)

--- a/libsodium.cabal
+++ b/libsodium.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: libsodium
-version: 1.0.18.3
+version: 1.0.19.0
 license: ISC
 license-file: LICENSE
 extra-source-files: README.md CHANGELOG.md
@@ -13,7 +13,7 @@ synopsis: Low-level bindings to the libsodium C library
 description: Low-level bindings to the libsodium C library
 homepage: https://github.com/k0001/hs-libsodium
 bug-reports: https://github.com/k0001/hs-libsodium/issues
-tested-with: GHC ==9.2.6
+tested-with: GHC ==9.4.8
 extra-source-files: c/*.h c/*.c
 
 
@@ -31,7 +31,7 @@ common basic
   default-language: GHC2021
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends: base == 4.*
-  pkgconfig-depends: libsodium == 1.0.18
+  pkgconfig-depends: libsodium == 1.0.19
   if flag(use-build-tool-depends)
     build-tool-depends: c2hs:c2hs
 


### PR DESCRIPTION
[ChangeLog](https://github.com/jedisct1/libsodium/blob/master/ChangeLog) appears to list no breaking changes.
Tested with `nix flake check`.
This does not add any of the new features.

- Closes #5